### PR TITLE
Bump aeson dependency lower bound to 2.0.

### DIFF
--- a/servant-errors.cabal
+++ b/servant-errors.cabal
@@ -28,7 +28,7 @@ source-repository head
 common common-options
   build-depends:       base  >= 4.10.0.0 && < 4.15
                      , base-compat >= 0.9.0
-                     , aeson >= 1.3 && < 1.6
+                     , aeson >= 2.0 && < 2.1
                      , text  >= 1.2
                      , wai   >= 3.2
 

--- a/src/Network/Wai/Middleware/Servant/Errors.hs
+++ b/src/Network/Wai/Middleware/Servant/Errors.hs
@@ -35,7 +35,8 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -57,12 +58,12 @@ module Network.Wai.Middleware.Servant.Errors
   , encodeAsPlainText
   )where
 
-import Prelude.Compat
-import Data.Aeson (Value (..), encode)
+import "base-compat" Prelude.Compat
+import Data.Aeson (encode, object, (.=))
+import Data.Aeson.Key (fromText)
 import qualified Data.ByteString as B
 import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.ByteString.Lazy as LB
-import qualified Data.HashMap.Strict as H
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.Kind (Type)
 import Data.List (find)
@@ -187,11 +188,10 @@ responseBody res =
 -- Its used in the library provided 'HasErrorBody' /JSON/ instance
 encodeAsJsonError :: ErrorLabels -> StatusCode -> ErrorMsg -> LB.ByteString
 encodeAsJsonError ErrorLabels {..} code content =
-  encode $ Object
-         $ H.fromList
-           [ (errName, String $ unErrorMsg content)
-           , (errStatusName, Number $ toScientific code )
-           ]
+  encode $ object
+    [ fromText errName .= unErrorMsg content
+    , fromText errStatusName .= toScientific code
+    ]
    where
      toScientific :: StatusCode -> Scientific
      toScientific = fromInteger . fromIntegral @_ @Integer . unStatusCode


### PR DESCRIPTION
Accounts for the new `aeson` 2.0 breaking changes.