### PR TITLE
Enable compatibility with GHC 9.0.2

### DIFF
--- a/servant-errors.cabal
+++ b/servant-errors.cabal
@@ -19,6 +19,7 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.6.5
                    , GHC == 8.8.3
                    , GHC == 8.8.4
+                   , GHC == 9.0.2
 
 
 source-repository head
@@ -26,7 +27,7 @@ source-repository head
   location:            https://github.com/epicallan/servant-errors.git
 
 common common-options
-  build-depends:       base  >= 4.10.0.0 && < 4.15
+  build-depends:       base  >= 4.10.0.0 && < 4.16
                      , base-compat >= 0.9.0
                      , aeson >= 1.3 && < 2.1
                      , text  >= 1.2


### PR DESCRIPTION
The current version of this library fails to compile with GHC 9.0.2. Bumping the upper version bound for `base` to `4.16` allows it to compile with no problems. 