### PR TITLE
Make ghc 9.2.4 compatible

### DIFF
--- a/servant-errors.cabal
+++ b/servant-errors.cabal
@@ -27,7 +27,7 @@ source-repository head
   location:            https://github.com/epicallan/servant-errors.git
 
 common common-options
-  build-depends:       base  >= 4.10.0.0 && < 4.16
+  build-depends:       base  >= 4.10.0.0 && < 4.18
                      , base-compat >= 0.9.0
                      , aeson >= 1.3 && < 2.1
                      , text  >= 1.2


### PR DESCRIPTION
Bumps base bounds to allow for base-4.17