### PR TITLE
Relaxed version bounds for Aeson and base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   - ghc: 8.4.4
   - ghc: 8.6.5
   - ghc: 8.8.3
+  - ghc: 9.2.5
 
 
 install:

--- a/servant-errors.cabal
+++ b/servant-errors.cabal
@@ -18,7 +18,8 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
-tested-with:     GHC ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.8.4 || ==9.0.2
+tested-with:
+  GHC ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.8.4 || ==9.0.2 || ==9.2.5
 
 source-repository head
   type:     git

--- a/servant-errors.cabal
+++ b/servant-errors.cabal
@@ -1,69 +1,66 @@
-cabal-version:       2.2
-name:                servant-errors
-version:             0.1.7.0
-synopsis:            Servant Errors wai-middlware
-description:         A Wai middleware that uniformly structures errors with in a servant application. The library assumes all HTTP responses with status code greater than 200 and without an HTTP content type are error responses. This assumption is derived from servant server error handling implementation.
+cabal-version:   2.2
+name:            servant-errors
+version:         0.1.7.0
+synopsis:        Servant Errors wai-middlware
+description:
+  A Wai middleware that uniformly structures errors with in a servant application. The library assumes all HTTP responses with status code greater than 200 and without an HTTP content type are error responses. This assumption is derived from servant server error handling implementation.
 
-homepage:            https://github.com/epicallan/servant-errors
-bug-reports:         https://github.com/epicallan/servant-errors/issues
-license:             MIT
-license-file:        LICENSE
-author:              Lukwago Allan
-maintainer:          epicallan.al@gmail.com
-copyright:           2019 Lukwago Allan
-category:            Network, Servant
-build-type:          Simple
-extra-doc-files:     README.md
-                   , CHANGELOG.md
-tested-with:         GHC == 8.4.4
-                   , GHC == 8.6.5
-                   , GHC == 8.8.3
-                   , GHC == 8.8.4
-                   , GHC == 9.0.2
+homepage:        https://github.com/epicallan/servant-errors
+bug-reports:     https://github.com/epicallan/servant-errors/issues
+license:         MIT
+license-file:    LICENSE
+author:          Lukwago Allan
+maintainer:      epicallan.al@gmail.com
+copyright:       2019 Lukwago Allan
+category:        Network, Servant
+build-type:      Simple
+extra-doc-files:
+  CHANGELOG.md
+  README.md
 
+tested-with:     GHC ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.8.4 || ==9.0.2
 
 source-repository head
-  type:                git
-  location:            https://github.com/epicallan/servant-errors.git
+  type:     git
+  location: https://github.com/epicallan/servant-errors.git
 
 common common-options
-  build-depends:       base  >= 4.10.0.0 && < 4.18
-                     , base-compat >= 0.9.0
-                     , aeson >= 1.3 && < 2.1
-                     , text  >= 1.2
-                     , wai   >= 3.2
+  build-depends:
+    , aeson        >=1.3      && <2.2
+    , base         >=4.10.0.0 && <4.18
+    , base-compat  >=0.9.0
+    , text         >=1.2
+    , wai          >=3.2
 
-  ghc-options:         -Wall
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wcompat
-                       -Widentities
-                       -Wredundant-constraints
-                       -fhide-source-paths
-                       -freverse-errors
-                       -Wpartial-fields
-  default-language:    Haskell2010
+  ghc-options:
+    -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wcompat -Widentities -Wredundant-constraints -fhide-source-paths
+    -freverse-errors -Wpartial-fields
+
+  default-language: Haskell2010
 
 library
-  import:              common-options
-  hs-source-dirs:      src
-  exposed-modules:     Network.Wai.Middleware.Servant.Errors
-  build-depends:       bytestring >= 0.10.8.2
-                     , http-types >= 0.12
-                     , http-api-data >= 0.3
-                     , http-media >= 0.7
-                     , scientific >= 0.3
-                     , servant >= 0.13
-                     , string-conversions >= 0.4
-                     , unordered-containers >= 0.2
+  import:          common-options
+  hs-source-dirs:  src
+  exposed-modules: Network.Wai.Middleware.Servant.Errors
+  build-depends:
+    , bytestring            >=0.10.8.2
+    , http-api-data         >=0.3
+    , http-media            >=0.7
+    , http-types            >=0.12
+    , scientific            >=0.3
+    , servant               >=0.13
+    , string-conversions    >=0.4
+    , unordered-containers  >=0.2
 
 test-suite readme
-  import:              common-options
-  build-depends:       servant-errors
-                     , servant-server >= 0.13
-                     , warp >= 3.2.26
+  import:             common-options
+  build-depends:
+    , servant-errors
+    , servant-server  >=0.13
+    , warp            >=3.2.26
 
-  main-is:             README.lhs
-  type:                exitcode-stdio-1.0
-  ghc-options:         -pgmL markdown-unlit
-  build-tool-depends:  markdown-unlit:markdown-unlit
+  main-is:            README.lhs
+  type:               exitcode-stdio-1.0
+  ghc-options:        -pgmL markdown-unlit
+  build-tool-depends: markdown-unlit:markdown-unlit

--- a/servant-errors.cabal
+++ b/servant-errors.cabal
@@ -27,7 +27,7 @@ source-repository head
 common common-options
   build-depends:
     , aeson        >=1.3      && <2.2
-    , base         >=4.10.0.0 && <4.18
+    , base         >=4.10.0.0 && <5
     , base-compat  >=0.9.0
     , text         >=1.2
     , wai          >=3.2


### PR DESCRIPTION
I was able to compile relaxing the versions of Aeson and base.